### PR TITLE
v0.5.6-stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Black Engine: Changelog
 =======================
 
+# v0.5.6
+### New features
+- Added `Graphics#cacheAsBitmapDynamic` property allowing to disable auto refresh of bitmap cache
+
+### Bug Fixes
+- Fixed few Cache As Bitmap bugs causing Graphics and tiling sprite to render incorrectly
+- Fixed incorrect rendering of cached slice9grid texture
+- Fixed incorrect rendering of tiled texture from texture atlas
+
+### Examples & Docs
+- Added "Cache As Bitmap Dynamic" example
+
 # v0.5.5
 ### New features
 - Added support for Black Vector Graphics (beta)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "black",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "",
   "main": "dist/black-es6-module.js",
   "directories": {},

--- a/src/display/DisplayObject.js
+++ b/src/display/DisplayObject.js
@@ -28,6 +28,9 @@ class DisplayObject extends GameObject {
     this.mCacheAsBitmap = false;
 
     /** @private @type {boolean} */
+    this.mCacheAsBitmapDynamic = true;
+
+    /** @private @type {boolean} */
     this.mCacheAsBitmapDirty = true;
 
     /** @private @type {Matrix|null} */
@@ -253,6 +256,24 @@ class DisplayObject extends GameObject {
 
       this.setTransformDirty();
     }
+  }
+
+  /**
+   * Gets/sets whenever cache as bitmap should be automatically refreshed.
+   * 
+   * @returns {boolean}
+   */
+  get cacheAsBitmapDynamic() {
+    return this.mCacheAsBitmapDynamic;
+  }
+
+  /**
+   * @ignore
+   * @param {boolean} value
+   * @return {void}
+   */
+  set cacheAsBitmapDynamic(value) {
+    this.mCacheAsBitmapDynamic = value;
   }
 
   /**

--- a/src/display/DisplayObject.js
+++ b/src/display/DisplayObject.js
@@ -48,11 +48,11 @@ class DisplayObject extends GameObject {
     /** @protected @type {boolean} */
     this.mSnapToPixels = false;
 
-    /** @protected @type {DisplayObject|null} */
-    this.mMask = null;
+    // /** @protected @type {DisplayObject|null} */
+    // this.mMask = null;
 
-    /** @protected @type {boolean} */
-    this.mIsMask = false;
+    // /** @protected @type {boolean} */
+    // this.mIsMask = false;
   }
 
   /**
@@ -380,29 +380,29 @@ class DisplayObject extends GameObject {
     this.mSnapToPixels = value;
   }
 
-  /**
-   * Gets/sets a display object which will act like a mask for this display object. 
-   * Mask should be a part on the stage.
-   * @returns {DisplayObject|null}
-   */
-  get mask() {
-    return this.mMask;
-  }
+  // /**
+  //  * Gets/sets a display object which will act like a mask for this display object. 
+  //  * Mask should be a part on the stage.
+  //  * @returns {DisplayObject|null}
+  //  */
+  // get mask() {
+  //   return this.mMask;
+  // }
 
-  /**
-   * @ignore
-   * @param {DisplayObject|null}
-   */
-  set mask(value) {
-    if (this.mMask === value)
-      return;
+  // /**
+  //  * @ignore
+  //  * @param {DisplayObject|null}
+  //  */
+  // set mask(value) {
+  //   if (this.mMask === value)
+  //     return;
 
-    if (this.mMask !== null) 
-      this.mMask.mIsMask = false;
+  //   if (this.mMask !== null) 
+  //     this.mMask.mIsMask = false;
 
-    if (value !== null) 
-      value.mIsMask = true;
+  //   if (value !== null) 
+  //     value.mIsMask = true;
 
-    this.mMask = value;
-  }
+  //   this.mMask = value;
+  // }
 }

--- a/src/drivers/canvas/DisplayObjectRendererCanvas.js
+++ b/src/drivers/canvas/DisplayObjectRendererCanvas.js
@@ -4,6 +4,7 @@
  * @extends Renderer
  * @cat drivers.canvas
  */
+
 /* @echo EXPORT */
 class DisplayObjectRendererCanvas extends Renderer {
   constructor() {
@@ -25,6 +26,9 @@ class DisplayObjectRendererCanvas extends Renderer {
     this.mIsClipped = false;
 
     this.mIsCached = false;
+
+    /** @private @type {Matrix|null} */
+    this.mBakeInvertedMatrix = null;
   }
 
   /** @inheritDoc */
@@ -93,20 +97,17 @@ class DisplayObjectRendererCanvas extends Renderer {
     let gameObject = /** @type {DisplayObject} */ (this.gameObject);
     let transform = gameObject.worldTransformation;
 
-
-    if (this.skipChildren === true){
+    if (this.skipChildren === true) {
       transform = this.mCacheAsBitmapMatrixCache;
 
       if (gameObject.mCacheAsBitmapDynamic === false) {
-        
-        
-      // here your solution
-        
-        
+        transform = new Matrix()
+          .append(this.gameObject.worldTransformation)
+          .append(this.mBakeInvertedMatrix)
+          .append(this.mCacheAsBitmapMatrixCache)
       }
     }
 
-    
 
     if (this.skipChildren === true || this.endPassRequired === true) {
       driver.setSnapToPixels(gameObject.snapToPixels);
@@ -161,7 +162,8 @@ class DisplayObjectRendererCanvas extends Renderer {
     this.mCacheAsBitmapMatrixCache.scale(1 / Black.driver.renderScaleFactor, 1 / Black.driver.renderScaleFactor);
     this.mCacheAsBitmapMatrixCache.data[4] = -this.mCacheAsBitmapMatrixCache.data[4];
     this.mCacheAsBitmapMatrixCache.data[5] = -this.mCacheAsBitmapMatrixCache.data[5];
-    
+
+    this.mBakeInvertedMatrix = this.gameObject.worldTransformation.clone().invert();
     //this.mCacheTexture.__dumpToDocument();
   }
 }

--- a/src/drivers/canvas/DisplayObjectRendererCanvas.js
+++ b/src/drivers/canvas/DisplayObjectRendererCanvas.js
@@ -23,6 +23,8 @@ class DisplayObjectRendererCanvas extends Renderer {
 
     /** @private @type {boolean} */
     this.mIsClipped = false;
+
+    this.mIsCached = false;
   }
 
   /** @inheritDoc */
@@ -33,15 +35,28 @@ class DisplayObjectRendererCanvas extends Renderer {
     this.endPassRequired = this.mIsClipped;
 
     if (gameObject.mCacheAsBitmap === true) {
-      let isStatic = gameObject.checkStatic(true);
-      if (isStatic === true && this.mCacheAsBitmapDirty === true) {
-        gameObject.setTransformDirty();
-        this.__refreshBitmapCache();
-        this.mCacheAsBitmapDirty = false;
-        this.endPassRequired = false;
-      } else if (isStatic === false) {
-        this.mCacheAsBitmapDirty = true;
-        gameObject.mDirty |= DirtyFlag.RENDER;
+      if (gameObject.mCacheAsBitmapDynamic === false) {
+        if (this.mIsCached === false) {
+          this.mIsCached = true;
+          gameObject.setTransformDirty();
+          this.__refreshBitmapCache();
+          this.mCacheAsBitmapDirty = false;
+          this.endPassRequired = false;
+        } else {
+          gameObject.mDirty |= DirtyFlag.RENDER;
+        }
+      } else {
+        let isStatic = gameObject.checkStatic(true);
+
+        if (isStatic === true && this.mCacheAsBitmapDirty === true) {
+          gameObject.setTransformDirty();
+          this.__refreshBitmapCache();
+          this.mCacheAsBitmapDirty = false;
+          this.endPassRequired = false;
+        } else if (isStatic === false) {
+          this.mCacheAsBitmapDirty = true;
+          gameObject.mDirty |= DirtyFlag.RENDER;
+        }
       }
     }
 
@@ -78,8 +93,20 @@ class DisplayObjectRendererCanvas extends Renderer {
     let gameObject = /** @type {DisplayObject} */ (this.gameObject);
     let transform = gameObject.worldTransformation;
 
-    if (this.skipChildren === true)
+
+    if (this.skipChildren === true){
       transform = this.mCacheAsBitmapMatrixCache;
+
+      if (gameObject.mCacheAsBitmapDynamic === false) {
+        
+        
+      // here your solution
+        
+        
+      }
+    }
+
+    
 
     if (this.skipChildren === true || this.endPassRequired === true) {
       driver.setSnapToPixels(gameObject.snapToPixels);
@@ -134,7 +161,7 @@ class DisplayObjectRendererCanvas extends Renderer {
     this.mCacheAsBitmapMatrixCache.scale(1 / Black.driver.renderScaleFactor, 1 / Black.driver.renderScaleFactor);
     this.mCacheAsBitmapMatrixCache.data[4] = -this.mCacheAsBitmapMatrixCache.data[4];
     this.mCacheAsBitmapMatrixCache.data[5] = -this.mCacheAsBitmapMatrixCache.data[5];
-
+    
     //this.mCacheTexture.__dumpToDocument();
   }
 }

--- a/src/parsers/BVGStyle.js
+++ b/src/parsers/BVGStyle.js
@@ -134,7 +134,7 @@ class BVGStyle {
    * @public
    * @param {BVGStyle} style Parent style
    *
-   * @returns void
+   * @returns {void}
    */
   merge(style) {
     if (style.hasOwnProperty('F'))
@@ -176,7 +176,7 @@ class BVGStyle {
    *
    * @public
    *
-   * @returns void
+   * @returns {void}
    */
   compute() {
     this.needsFill = this.F !== '-';

--- a/src/timers/Timer.js
+++ b/src/timers/Timer.js
@@ -1,6 +1,8 @@
 /**
  * Timer component.
  *
+ * @cat timers
+ * 
  * @fires Timer#complete
  * @fires Timer#tick
  * 


### PR DESCRIPTION
# v0.5.6
### New features
- Added `Graphics#cacheAsBitmapDynamic` property allowing to disable auto refresh of bitmap cache

### Bug Fixes
- Fixed few Cache As Bitmap bugs causing Graphics and tiling sprite to render incorrectly
- Fixed incorrect rendering of cached slice9grid texture
- Fixed incorrect rendering of tiled texture from texture atlas

### Examples & Docs
- Added "Cache As Bitmap Dynamic" example
